### PR TITLE
Consumer and Prediction Service(tornado) split

### DIFF
--- a/consumer/README.md
+++ b/consumer/README.md
@@ -1,10 +1,15 @@
 ## Image Consumer
-There are three versions of scripts written:    
-**1) consumer_shakeshack.py** for the Shakeshack Images    
-**2) consumer_storage.py** for the Images in local storage    
-**3) consumer_storage_tornado.py** for the Images in local storage plus the consumer is a tornado web application that serves the predictions    
+There are two modes of operation for the consumer plus prediction service for static images:   
+**1) Single Service that acts both as the consumer and the prediction service**  
+**2) Two separate services for the consumer and the prediction service**
 
-Note that the scripts run in an infinite loop consuming messages. For the consumer_storage_tornado script, there is an **IMAGE_FREQUENCY** parameter which dictates how often the consumer consumes a message. This is required because the consumer runs on a single thread but also needs to act as a tornado app that serves the predictions required for the dashboard. The **IMAGE_FREQUENCY** is the duration for which execution is yielded between message consumption - this allows the tornado app to respond to the requests coming its way. The current version of the script makes the prediction available on port 8080 on localhost. This can be set up on cloud to be accessible over the internet.    
+For option 1, we need to run the **consumer_storage_tornado.py** script. This service receives messages from the Kafka topic, calls the Azure Model API, manipulates the response and then exposes the prediction using a REST API built using Tornado.
+
+For option 2, we need to run both the **consumer_storage.py** script and the **prediction_service.py** script. The former script consumes messages from Kafka, calls the Azure Model API, manipulates the response and then saves the prediction to local storage. The latter script reads the predictions from local storage and exposes the prediction using a REST API built using Tornado.
+
+The advantage of using option 2 is that the consumer and the prediction services can be scaled independently. Moreoever, as there are two processes but only one thread for execution in option 1, the REST requests sometimes receive a slow response (some latency) - more info on this at the end of the README. So the preferred option is option 2.
+
+Note that the scripts run in an infinite loop consuming messages. The current version of the script makes the prediction available on port 8080 on localhost. This can be set up on cloud to be accessible over the internet.
 
 Before using any of these scripts:
 1) If the host IP/port for the Kafka broker is not `127.0.0.1:9092` or if the topic name is not `people-detection`, update the consumer script
@@ -13,3 +18,14 @@ Before using any of these scripts:
 ```
 python3 consumer_storage_tornado.py 30
 ```
+4) If using the **consumer_storage.py** and the **prediction_service.py** scripts, there is an optional argument **PREDICTION_DIR_PATH** that can be passed during script execution. This is the temporary path (directory can either be relative or absolute) where the prediction is pickled and stored by the consumer service and consequently the path from which the prediction service reads the prediction before it makes it available over the REST API. If this is not passed, it needs to be set **manually** in the scripts. Note that the value defaults to a local path on my machine currently and **has** to be updated
+```
+python3 consumer_storage.py /Users/user1/Downloads
+python3 prediction_service.py /Users/user1/Downloads
+```
+Please ensure that both the arguments contain the same path
+
+**Note explaining why separate services is better:** For the consumer_storage_tornado script, there is an **IMAGE_FREQUENCY** parameter which dictates how often the consumer consumes a message. This is required because the consumer runs on a single thread but also needs to act as a tornado app that serves the predictions required for the dashboard. The **IMAGE_FREQUENCY** is the duration for which execution is yielded between message consumption - this allows the tornado app to respond to the requests coming its way
+
+
+**Note:** If the shakeshack images are used, the **consumer_shakeshack.py** script can be used to run the consumer service. However, this service currently only receives images from Kafka and prints the image dimensions. It needs to be updated to make the call to the Model API and then host the results in a Tornado app before it can be used

--- a/consumer/consumer_storage.py
+++ b/consumer/consumer_storage.py
@@ -8,6 +8,8 @@ from pykafka.common import OffsetType
 import requests
 import os
 
+PREDICTION_DIR_PATH = '/Users/harish/IdeaProjects/datascience_certification/data_analytics_pipeline/project/prediction'
+
 
 def gen_client(hosts="127.0.0.1:9092", topic_name='people-detection'):
     client = KafkaClient(hosts=hosts)
@@ -28,8 +30,12 @@ def model(msg):
         'Prediction-Key': os.getenv('AZURE_VIS_KEY'),
         'Content-Type': 'application/octet-stream'
     }
+    print("Calling the vision API")
     r = requests.post(url=url, headers=headers, data=msg['img'])
     predictions = r.json()
+    prediction_json = {'num_of_predictions': len(predictions['predictions'])}
+    pickle.dump(prediction_json, open(
+        '{}/pred.pickle'.format(PREDICTION_DIR_PATH), 'wb'))
     print('Number of object predictions: {}'.format(
         len(predictions['predictions'])))
     print('Frame Number:', msg['frame_num'],

--- a/consumer/consumer_storage.py
+++ b/consumer/consumer_storage.py
@@ -7,6 +7,7 @@ from pykafka import KafkaClient
 from pykafka.common import OffsetType
 import requests
 import os
+import sys
 
 PREDICTION_DIR_PATH = '/Users/harish/IdeaProjects/datascience_certification/data_analytics_pipeline/project/prediction'
 
@@ -43,6 +44,9 @@ def model(msg):
 
 
 if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        PREDICTION_DIR_PATH = int(sys.argv[1])
+
     client, topic = gen_client(
         hosts="127.0.0.1:9092", topic_name='people-detection')
     consumer = topic.get_simple_consumer(fetch_message_max_bytes=104857600)

--- a/consumer/prediction_service.py
+++ b/consumer/prediction_service.py
@@ -1,0 +1,38 @@
+import pickle
+from tornado import gen, httpserver, ioloop, log, web
+
+
+PREDICTION_DIR_PATH = '/Users/harish/IdeaProjects/datascience_certification/data_analytics_pipeline/project/prediction'
+
+
+class MainHandler(web.RequestHandler):
+    @gen.coroutine
+    def get(self):
+        prediction_json = pickle.load(
+            open('{}/pred.pickle'.format(PREDICTION_DIR_PATH), 'rb'))
+        self.write(prediction_json)
+
+
+def make_app():
+    return web.Application([
+        (r"/", MainHandler)
+    ],
+        debug=False)
+
+
+def main():
+    app = make_app()
+    # start server
+    server = httpserver.HTTPServer(app)
+    server.listen(8080)
+
+    print('starting ioloop')
+    ioloop.IOLoop.instance().start()
+
+
+if __name__ == "__main__":
+    main()
+
+# To dos:
+# Dockerize the application
+# Improve the consumer - just return the last unconsumed message in a non-blocking manner

--- a/consumer/prediction_service.py
+++ b/consumer/prediction_service.py
@@ -1,6 +1,6 @@
 import pickle
 from tornado import gen, httpserver, ioloop, log, web
-
+import sys
 
 PREDICTION_DIR_PATH = '/Users/harish/IdeaProjects/datascience_certification/data_analytics_pipeline/project/prediction'
 
@@ -31,6 +31,9 @@ def main():
 
 
 if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        PREDICTION_DIR_PATH = int(sys.argv[1])
+
     main()
 
 # To dos:

--- a/producer/README.md
+++ b/producer/README.md
@@ -31,15 +31,15 @@ This script sets up the producer for the images in local storage. The script is 
 Ex: frame_60.jpg, frame_120.jpg, etc  
 
 This script takes three arguments:  
-**IMAGE_DIR_PATH:** Path to the folder containing the images  
-Default value: `video_to_images`  
+**IMAGE_DIR_PATH:** Local path (can either be relative or absolute) to the folder containing the images  
+Default value: Directory in my local path - so this **has** to either be passed or manually updated in the script  
 **IMAGE_FREQUENCY:** Number of seconds between consecutive reads from local storage for images to be sent to Kafka.  
-Default value: `5`  
+Default value: `5`    
 **PRODUCER_TYPE:** `loop` or `random`  
 *loop:* Read images in the folder in a loop in the order of frame number  
 *random:* Read random images from the folder  
 Default value: `loop`  
 
 ```
-python3 producer_storage.py video_to_images 5 loop
+python3 producer_storage.py /Users/user1/Downloads/video_to_images 5 loop
 ```

--- a/producer/producer_storage.py
+++ b/producer/producer_storage.py
@@ -8,7 +8,7 @@ import time
 import random
 import sys
 
-IMAGE_DIR_PATH = 'video_to_images'
+IMAGE_DIR_PATH = '/Users/harish/IdeaProjects/datascience_certification/data_analytics_pipeline/project/video_to_images'
 IMAGE_FREQUENCY = 5
 PRODUCER_TYPE = 'loop'
 


### PR DESCRIPTION
The current setup involves one service/app that acts both as the consumer and the prediction service(which exposes the prediction using a REST API built using Tornado). As there are two processes but only one thread for execution, the REST requests sometimes receive a slow response (some latency). Also, these services cannot be independently scaled. Therefore, this branch sets up two separate services for the consumer(consumer_storage.py) and the prediction service(prediction_service.py)